### PR TITLE
timestamp down to millisecond precision

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shinylogs
 Title: Record Everything that Happens in a 'Shiny' Application
-Version: 0.1.7.900
+Version: 0.1.7.9000
 Authors@R: c(person("Fanny", "Meyer", email = "fanny.meyer@dreamrs.fr", role = c("aut")),
   person("Victor", "Perrier", email = "victor.perrier@dreamrs.fr", role = c("aut", "cre")),
   person("Silex Technologies", comment = "https://www.silex-ip.com", role = "fnd"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # shinylogs 0.1.7
 
 * Fix a bug when used with {shinymanager} (fix [#2](https://github.com/dreamRs/shinylogs/issues/2)).
+* Timestamp is now recorded in microseconds (fix [#6](https://github.com/dreamRs/shinylogs/issues/6)).
 
 
 # shinylogs 0.1.6

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,7 +7,7 @@ dropNulls <- function(x) {
 get_timestamp <- function(time = NULL) {
   if (is.null(time))
     time <- Sys.time()
-  format(time, format = "%Y-%m-%dT%H:%M:%S%z")
+  format(time, format = "%Y-%m-%d %H:%M:%OS3%z")
 }
 
 is_sqlite <- function(path) {

--- a/inst/assets/js/shinylogs-localForage.js
+++ b/inst/assets/js/shinylogs-localForage.js
@@ -67,7 +67,7 @@ var browser_res = w + "x" + h;
 // Pixel ratio
 var pixel_ratio = window.devicePixelRatio;
 // Timestamp browser
-var browser_connected = dayjs().format();
+var browser_connected = dayjs().format("YYYY-MM-DD HH:mm:ss.SSSZZ");
 
 // Send browser data
 if (logsonunload === false) {
@@ -110,7 +110,7 @@ $(document).on("shiny:inputchanged", function(event) {
     (event.inputType != "shiny.password")
   ) {
     //console.log(event); "shiny.password"
-    var ts = dayjs(event.timeStamp).format();
+    var ts = dayjs(event.timeStamp).format("YYYY-MM-DD HH:mm:ss.SSSZZ");
     var inputId = 'input' + generateId();
     var lastInput = {
       name: event.name,
@@ -133,7 +133,7 @@ $(document).on("shiny:inputchanged", function(event) {
 // Track ERRORS
 $(document).on("shiny:error", function(event) {
   //console.log(event);
-  var ts = dayjs(event.timeStamp).format();
+  var ts = dayjs(event.timeStamp).format("YYYY-MM-DD HH:mm:ss.SSSZZ");
   var errorId = 'error' + generateId();
   var lastError = {
     name: event.name,
@@ -152,7 +152,7 @@ $(document).on("shiny:error", function(event) {
 // Track OUTPUTs
 $(document).on("shiny:value", function(event) {
   //console.log(event);
-  var ts = dayjs(event.timeStamp).format();
+  var ts = dayjs(event.timeStamp).format("YYYY-MM-DD HH:mm:ss.SSSZZ");
   var outputId = 'output' + generateId();
   var lastOutput = {
     name: event.name,

--- a/inst/assets/js/shinylogs-lowdb.js
+++ b/inst/assets/js/shinylogs-lowdb.js
@@ -58,7 +58,7 @@ var browser_res = w + "x" + h;
 var pixel_ratio = window.devicePixelRatio;
 
 // Timestamp browser
-var browser_connected = dayjs().format();
+var browser_connected = dayjs().format("YYYY-MM-DD HH:mm:ss.SSSZZ");
 
 // Send browser data
 if (logsonunload === false) {
@@ -85,7 +85,7 @@ $(document).on("shiny:inputchanged", function(event) {
     //console.log(event);
     var lastInput = {
       name: event.name,
-      timestamp: dayjs(event.timeStamp).format(),
+      timestamp: dayjs(event.timeStamp).format("YYYY-MM-DD HH:mm:ss.SSSZZ"),
       value: event.value,
       type: event.inputType,
       binding: event.binding !== null ? event.binding.name : ''
@@ -110,7 +110,7 @@ $(document).on("shiny:error", function(event) {
   if (dont_track.indexOf(event.name) == -1) {
     var lastError = {
       name: event.name,
-      timestamp: dayjs(event.timeStamp).format(),
+      timestamp: dayjs().format("YYYY-MM-DD HH:mm:ss.SSSZZ"),
       error: event.error.message
     };
     db.get("error").push(lastError).write();
@@ -129,7 +129,7 @@ $(document).on("shiny:value", function(event) {
   //console.log(event);
   var lastOutput = {
     name: event.name,
-    timestamp: dayjs(event.timeStamp).format(),
+    timestamp: dayjs().format("YYYY-MM-DD HH:mm:ss.SSSZZ"),
     binding: event.binding.binding.name
   };
   db.get("output").push(lastOutput).write();


### PR DESCRIPTION
In version 0.1.7.900, timestamp is recorded down to the second. This is not enough since several events can occur during 1sec. This version tracks time down to the millisecond. This is related to issue #6.