### PR TITLE
Add option of defining app_name

### DIFF
--- a/R/tracking.R
+++ b/R/tracking.R
@@ -12,7 +12,8 @@
 #'  be created only on close, downside is that a popup will appear asking to close the page.
 #' @param exclude_input_regex Regular expression to exclude inputs from tracking.
 #' @param exclude_input_id Vector of `inputId` to exclude from tracking.
-#'
+#' @param app_name Name of the app as a character string. If `NULL`, `basename(getwd())` is used.
+#' 
 #' @note The following `input`s will be accessible in the server:
 #'
 #'   - **.shinylogs_lastInput** : last `input` used by the user
@@ -34,8 +35,12 @@
 #' @importFrom digest digest
 #'
 #' @example examples/use_tracking.R
-use_tracking <- function(on_unload = FALSE, exclude_input_regex = NULL, exclude_input_id = NULL) {
-  app_name <- basename(getwd())
+use_tracking <- function(on_unload = FALSE, 
+                         exclude_input_regex = NULL, 
+                         exclude_input_id = NULL,
+                         app_name = NULL) {
+  if (is.null(app_name)) 
+    app_name <- basename(getwd())
   timestamp <- Sys.time()
   init_log <- data.frame(
     app = app_name,
@@ -98,6 +103,7 @@ parse_lastInput <- function(x, shinysession, name) {
 #'  input during normal use of the application, there will
 #'  be created only on close, downside is that a popup will appear asking to close the page.
 #' @param exclude_users Character vectors of user for whom it is not necessary to save the log.
+#' @param app_name Name of the app as a character string. If `NULL`, `basename(getwd())` is used.
 #' @param get_user A `function` to get user name, it should
 #'  return a character and take one argument: the Shiny session.
 #' @param dependencies Load dependencies in client, can be set to `FALSE` if [use_tracking()] has been called in UI.
@@ -131,13 +137,15 @@ track_usage <- function(storage_mode,
                         exclude_input_id = NULL,
                         on_unload = FALSE,
                         exclude_users = NULL,
+                        app_name = NULL,
                         get_user = NULL,
                         dependencies = TRUE,
                         session = getDefaultReactiveDomain()) {
 
   stopifnot(inherits(storage_mode, "shinylogs.storage_mode"))
 
-  app_name <- basename(getwd())
+  if (is.null(app_name))
+    app_name <- basename(getwd())
   if (is.null(get_user))
     get_user <- get_user_
   if (!is.function(get_user))

--- a/R/tracking.R
+++ b/R/tracking.R
@@ -102,8 +102,8 @@ parse_lastInput <- function(x, shinysession, name) {
 #'  if `TRUE` it prevent to create `shinylogs`
 #'  input during normal use of the application, there will
 #'  be created only on close, downside is that a popup will appear asking to close the page.
-#' @param exclude_users Character vectors of user for whom it is not necessary to save the log.
 #' @param app_name Name of the app as a character string. If `NULL`, `basename(getwd())` is used.
+#' @param exclude_users Character vectors of user for whom it is not necessary to save the log.
 #' @param get_user A `function` to get user name, it should
 #'  return a character and take one argument: the Shiny session.
 #' @param dependencies Load dependencies in client, can be set to `FALSE` if [use_tracking()] has been called in UI.
@@ -136,8 +136,8 @@ track_usage <- function(storage_mode,
                         exclude_input_regex = NULL,
                         exclude_input_id = NULL,
                         on_unload = FALSE,
-                        exclude_users = NULL,
                         app_name = NULL,
+                        exclude_users = NULL,
                         get_user = NULL,
                         dependencies = TRUE,
                         session = getDefaultReactiveDomain()) {

--- a/man/track_usage.Rd
+++ b/man/track_usage.Rd
@@ -10,6 +10,7 @@ track_usage(
   exclude_input_id = NULL,
   on_unload = FALSE,
   exclude_users = NULL,
+  app_name = NULL,
   get_user = NULL,
   dependencies = TRUE,
   session = getDefaultReactiveDomain()
@@ -29,6 +30,8 @@ input during normal use of the application, there will
 be created only on close, downside is that a popup will appear asking to close the page.}
 
 \item{exclude_users}{Character vectors of user for whom it is not necessary to save the log.}
+
+\item{app_name}{Name of the app as a character string. If \code{NULL}, \code{basename(getwd())} is used.}
 
 \item{get_user}{A \code{function} to get user name, it should
 return a character and take one argument: the Shiny session.}

--- a/man/track_usage.Rd
+++ b/man/track_usage.Rd
@@ -9,8 +9,8 @@ track_usage(
   exclude_input_regex = NULL,
   exclude_input_id = NULL,
   on_unload = FALSE,
-  exclude_users = NULL,
   app_name = NULL,
+  exclude_users = NULL,
   get_user = NULL,
   dependencies = TRUE,
   session = getDefaultReactiveDomain()
@@ -29,9 +29,9 @@ if \code{TRUE} it prevent to create \code{shinylogs}
 input during normal use of the application, there will
 be created only on close, downside is that a popup will appear asking to close the page.}
 
-\item{exclude_users}{Character vectors of user for whom it is not necessary to save the log.}
-
 \item{app_name}{Name of the app as a character string. If \code{NULL}, \code{basename(getwd())} is used.}
+
+\item{exclude_users}{Character vectors of user for whom it is not necessary to save the log.}
 
 \item{get_user}{A \code{function} to get user name, it should
 return a character and take one argument: the Shiny session.}

--- a/man/use_tracking.Rd
+++ b/man/use_tracking.Rd
@@ -7,7 +7,8 @@
 use_tracking(
   on_unload = FALSE,
   exclude_input_regex = NULL,
-  exclude_input_id = NULL
+  exclude_input_id = NULL,
+  app_name = NULL
 )
 }
 \arguments{
@@ -19,6 +20,8 @@ be created only on close, downside is that a popup will appear asking to close t
 \item{exclude_input_regex}{Regular expression to exclude inputs from tracking.}
 
 \item{exclude_input_id}{Vector of \code{inputId} to exclude from tracking.}
+
+\item{app_name}{Name of the app as a character string. If \code{NULL}, \code{basename(getwd())} is used.}
 }
 \description{
 If used in UI of an application,


### PR DESCRIPTION
Hi there! Thanks for this great package. 

I'd like to start using it with a a collection of apps I have deployed using shinyproxy. The issue I have is that all apps are copied as volumes into a `root/app/` directory of a docker container and so the default `app_name <- basename(getwd())` results in the same "app" name for each app in the session logs.

This PR adds the option of defining it manually in the `use_tracking` and `track_usage` functions. 

Merci!

