### PR TITLE
Add check for Shinyproxy username HTTP header

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -16,6 +16,8 @@ is_sqlite <- function(path) {
 get_user_ <- function(session) {
   if (!is.null(session$user))
     return(session$user)
+  if (!is.null(session$request$HTTP_X_SP_USERID))
+    return(session$request$HTTP_X_SP_USERID)
   user <- Sys.getenv("SHINYPROXY_USERNAME")
   if (!identical(user, "")) {
     return(user)


### PR DESCRIPTION
Shinyproxy now has the option of [sharing containers amongst multiple users](https://shinyproxy.io/documentation/configuration/#container-pre-initialization-and-sharing). In this case, usernames are passed to the shiny session as a HTTP header rather than an environment variable ([full details here](https://github.com/openanalytics/shinyproxy-shiny-demo-auth)). This PR adds a check for the header in the session and returns it if not null in the `get_user_` function. 